### PR TITLE
feat: implement localStorage save/load for SimpleTable #12

### DIFF
--- a/arcana-screen/src/components/Grid.tsx
+++ b/arcana-screen/src/components/Grid.tsx
@@ -1,20 +1,21 @@
 import { DndProvider, useDrag, useDrop } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
-import { useState } from 'react';
+import { useCallback } from 'react';
 import QuickNotes from './widgets/QuickNotes';
 import DiceRoller from './widgets/DiceRoller';
 import CountdownTimer from './widgets/CountdownTimer';
 import SimpleTable from './widgets/SimpleTable';
 import InitiativeTracker from './widgets/InitiativeTracker';
+import { useWidgetStore } from '../store/useWidgetStore';
 
 const ItemType = 'WIDGET';
 
-
-const components: { [key: number]: typeof QuickNotes } = {
-  1: SimpleTable,
-  2: CountdownTimer,
-  3: DiceRoller,
-  4: InitiativeTracker
+const components: { [key: string]: React.FC<any> } = {
+  SimpleTable,
+  CountdownTimer,
+  DiceRoller,
+  InitiativeTracker,
+  QuickNotes,
 };
 
 function DraggableBox({ id, index, moveItem, children }: any) {
@@ -45,25 +46,85 @@ function DraggableBox({ id, index, moveItem, children }: any) {
   );
 }
 
-export default function Grid() {
-  const [items, setItems] = useState([1, 2, 3, 4]);
+import { useEffect } from 'react';
 
-  const moveItem = (from: number, to: number) => {
-    const updated = [...items];
+export default function Grid() {
+  const widgets = useWidgetStore((state) => state.widgets);
+  const updateWidget = useWidgetStore((state) => state.updateWidget);
+  const removeWidget = useWidgetStore((state) => state.removeWidget);
+  const addWidget = useWidgetStore((state) => state.addWidget);
+  const clearWidgets = useWidgetStore((state) => state.clearWidgets);
+
+  useEffect(() => {
+    if (widgets.length === 0) {
+      addWidget({
+        id: 'table-1',
+        type: 'SimpleTable',
+        position: { x: 0, y: 0 },
+        size: { w: 4, h: 4 },
+        columns: [
+          { id: 1, key: 'name', label: 'Nome' },
+          { id: 2, key: 'value', label: 'Valore' }
+        ],
+        rows: [
+          { id: 1, name: 'Esempio', value: '42' },
+          { id: 2, name: 'Altro', value: '17' }
+        ]
+      });
+      addWidget({
+        id: 'timer-1',
+        type: 'CountdownTimer',
+        position: { x: 4, y: 0 },
+        size: { w: 2, h: 2 },
+        seconds: 60,
+        isRunning: false
+      });
+      addWidget({
+        id: 'dice-1',
+        type: 'DiceRoller',
+        position: { x: 0, y: 4 },
+        size: { w: 2, h: 2 },
+        diceType: 20,
+        numDice: 1,
+        modifier: 0,
+        advantage: 'none',
+        formula: '',
+        results: [],
+        finalResult: null
+      });
+      addWidget({
+        id: 'init-1',
+        type: 'InitiativeTracker',
+        position: { x: 2, y: 4 },
+        size: { w: 4, h: 3 },
+        combatants: [],
+        name: '',
+        initiative: 0,
+        currentIndex: null,
+        turnChangeAnimation: false
+      });
+    }
+  }, [widgets, addWidget]);
+
+  const moveItem = useCallback((from: number, to: number) => {
+    if (from === to) return;
+    const updated = [...widgets];
     const [moved] = updated.splice(from, 1);
     updated.splice(to, 0, moved);
-    setItems(updated);
-  };
+    // Update the widgets order in the store
+    clearWidgets();
+    updated.forEach(w => addWidget(w));
+  }, [widgets, clearWidgets, addWidget]);
 
   return (
     <DndProvider backend={HTML5Backend}>
       <div className="grid grid-cols-3 gap-4 p-8">
-        {items.map((id, index) => {
-          const WidgetComponent = components[id];
+        {widgets.map((widget, index) => {
+          const WidgetComponent = components[widget.type] || (() => null);
           return (
-            <div key={id} className="h-64">
-              <DraggableBox id={id} index={index} moveItem={moveItem}>
-                <WidgetComponent />
+            <div key={widget.id} className="h-64">
+              <DraggableBox id={widget.id} index={index} moveItem={moveItem}>
+                <WidgetComponent {...widget} updateWidget={updateWidget} removeWidget={removeWidget} />
               </DraggableBox>
             </div>
           );

--- a/arcana-screen/src/components/widgets/DiceRoller.tsx
+++ b/arcana-screen/src/components/widgets/DiceRoller.tsx
@@ -1,14 +1,36 @@
-import { useState } from 'react';
+import { useEffect } from 'react';
+import { useWidgetStore } from '../../store/useWidgetStore';
 import { DiceD2, DiceD4, DiceD6, DiceD8, DiceD10, DiceD12, DiceD20, DiceD100 } from './DiceIcons';
 
-export default function DiceRoller() {
-  const [diceType, setDiceType] = useState(20);
-  const [numDice, setNumDice] = useState(1);
-  const [modifier, setModifier] = useState(0);
-  const [advantage, setAdvantage] = useState<'none' | 'adv' | 'dis'>('none');
-  const [formula, setFormula] = useState('');
-  const [results, setResults] = useState<number[]>([]);
-  const [finalResult, setFinalResult] = useState<number | null>(null);
+interface DiceRollerProps {
+  id: string;
+  updateWidget: (id: string, updates: any) => void;
+}
+
+export default function DiceRoller({ id, updateWidget }: DiceRollerProps) {
+  const widget = useWidgetStore(state => state.widgets.find(w => w.id === id));
+
+  useEffect(() => {
+    if (!widget?.diceType) {
+      updateWidget(id, { diceType: 20, numDice: 1, modifier: 0, advantage: 'none', formula: '', results: [], finalResult: null });
+    }
+  }, [widget, id, updateWidget]);
+
+  const diceType = widget?.diceType || 20;
+  const numDice = widget?.numDice || 1;
+  const modifier = widget?.modifier || 0;
+  const advantage = widget?.advantage || 'none';
+  const formula = widget?.formula || '';
+  const results = widget?.results || [];
+  const finalResult = widget?.finalResult || null;
+
+  const setDiceType = (v: number) => updateWidget(id, { diceType: v });
+  const setNumDice = (v: number) => updateWidget(id, { numDice: v });
+  const setModifier = (v: number) => updateWidget(id, { modifier: v });
+  const setAdvantage = (v: 'none' | 'adv' | 'dis') => updateWidget(id, { advantage: v });
+  const setFormula = (v: string) => updateWidget(id, { formula: v });
+  const setResults = (v: number[]) => updateWidget(id, { results: v });
+  const setFinalResult = (v: number | null) => updateWidget(id, { finalResult: v });
 
   const diceOptions = [
     {sides: 2, icon: <DiceD2 />},

--- a/arcana-screen/src/store/useWidgetStore.ts
+++ b/arcana-screen/src/store/useWidgetStore.ts
@@ -1,0 +1,76 @@
+// src/store/useWidgetStore.ts
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export interface TableColumn {
+  id: number;
+  key: string;
+  label: string;
+}
+
+export interface TableRow {
+  id: number;
+  [key: string]: any;
+}
+
+export interface Combatant {
+  id: number;
+  name: string;
+  initiative: number;
+}
+
+interface Widget {
+  id: string;
+  type: string;
+  position: { x: number; y: number };
+  size: { w: number; h: number };
+  // SimpleTable
+  columns?: TableColumn[];
+  rows?: TableRow[];
+  // CountdownTimer
+  seconds?: number;
+  isRunning?: boolean;
+  // DiceRoller
+  diceType?: number;
+  numDice?: number;
+  modifier?: number;
+  advantage?: 'none' | 'adv' | 'dis';
+  formula?: string;
+  results?: number[];
+  finalResult?: number | null;
+  // InitiativeTracker
+  combatants?: Combatant[];
+  name?: string;
+  initiative?: number;
+  currentIndex?: number | null;
+  turnChangeAnimation?: boolean;
+}
+
+interface WidgetStore {
+  widgets: Widget[];
+  addWidget: (widget: Widget) => void;
+  updateWidget: (id: string, updates: Partial<Widget>) => void;
+  removeWidget: (id: string) => void;
+  clearWidgets: () => void;
+}
+
+export const useWidgetStore = create<WidgetStore>()(
+  persist(
+    (set, get) => ({
+      widgets: [],
+      addWidget: (widget) => set({ widgets: [...get().widgets, widget] }),
+      updateWidget: (id, updates) =>
+        set({
+          widgets: get().widgets.map((w) =>
+            w.id === id ? { ...w, ...updates } : w
+          ),
+        }),
+      removeWidget: (id) =>
+        set({ widgets: get().widgets.filter((w) => w.id !== id) }),
+      clearWidgets: () => set({ widgets: [] }),
+    }),
+    {
+      name: 'arcanaScreenLayout', // Nome della chiave in localStorage
+    }
+  )
+);

--- a/arcana-screen/src/utils/localStorageManager.tsx
+++ b/arcana-screen/src/utils/localStorageManager.tsx
@@ -1,0 +1,29 @@
+const STORAGE_KEY = 'arcanaScreenLayout';
+
+export function saveLayout(layout: any) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(layout));
+  } catch (error) {
+    console.error('Error saving layout:', error);
+  }
+}
+
+export function loadLayout(): any[] {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      return JSON.parse(stored);
+    }
+  } catch (error) {
+    console.error('Error loading layout:', error);
+  }
+  return [];
+}
+
+export function clearLayout() {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch (error) {
+    console.error('Error clearing layout:', error);
+  }
+}


### PR DESCRIPTION
# ✨ Implement LocalStorage Save/Load (Work Item #12)

## What was done
- Added `localStorageManager.ts` utility.
- Integrated auto-save on add/update/remove widget.
- Auto-load saved layout when the app starts.

## How to test
- Add/move/delete widgets -> reload the app -> layout should persist.
- Clear localStorage manually to test fallback.

## Notes
- No breaking changes.
- Clean foundation for future "multiple profiles" feature.

Closes #12