### PR TITLE
feat: implement profile manager with Zustand and localStorage persistence #13

### DIFF
--- a/arcana-screen/package-lock.json
+++ b/arcana-screen/package-lock.json
@@ -32,6 +32,7 @@
         "prettier": "^3.5.3",
         "react-dnd": "^16.0.1",
         "react-dnd-html5-backend": "^16.0.1",
+        "react-hot-toast": "^2.5.2",
         "tailwindcss": "^4.1.4",
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.26.1",
@@ -3366,6 +3367,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -4866,6 +4877,24 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
+      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/arcana-screen/package.json
+++ b/arcana-screen/package.json
@@ -34,6 +34,7 @@
     "prettier": "^3.5.3",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
+    "react-hot-toast": "^2.5.2",
     "tailwindcss": "^4.1.4",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.26.1",

--- a/arcana-screen/src/App.tsx
+++ b/arcana-screen/src/App.tsx
@@ -2,11 +2,14 @@ import Grid from './components/Grid';
 import { useThemeStore } from './store/themeStore';
 import './index.css';
 
+import { Toaster } from 'react-hot-toast';
+
 function App() {
   const { theme, toggleTheme } = useThemeStore();
 
   return (
     <div className={`h-screen w-screen flex flex-col ${theme === 'dark' ? 'bg-dark-parchment text-white' : 'bg-parchment text-gray-900'}`}>
+      <Toaster />
       
       <header className={`p-4 text-center border-b border-gray-700 ${theme === 'dark' ? 'dark-mode-text' : ''}`}>
         <h1 className="text-3xl font-bold">ArcanaScreen</h1>

--- a/arcana-screen/src/components/Grid.tsx
+++ b/arcana-screen/src/components/Grid.tsx
@@ -1,12 +1,14 @@
 import { DndProvider, useDrag, useDrop } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import QuickNotes from './widgets/QuickNotes';
 import DiceRoller from './widgets/DiceRoller';
 import CountdownTimer from './widgets/CountdownTimer';
 import SimpleTable from './widgets/SimpleTable';
 import InitiativeTracker from './widgets/InitiativeTracker';
 import { useWidgetStore } from '../store/useWidgetStore';
+import ProfileManagerPanel from './ProfileManagerPanel';
+
 
 const ItemType = 'WIDGET';
 
@@ -46,7 +48,6 @@ function DraggableBox({ id, index, moveItem, children }: any) {
   );
 }
 
-import { useEffect } from 'react';
 
 export default function Grid() {
   const widgets = useWidgetStore((state) => state.widgets);
@@ -118,6 +119,7 @@ export default function Grid() {
 
   return (
     <DndProvider backend={HTML5Backend}>
+      <ProfileManagerPanel />
       <div className="grid grid-cols-3 gap-4 p-8">
         {widgets.map((widget, index) => {
           const WidgetComponent = components[widget.type] || (() => null);

--- a/arcana-screen/src/components/ProfileManager.tsx
+++ b/arcana-screen/src/components/ProfileManager.tsx
@@ -1,0 +1,84 @@
+import { useState, ChangeEvent } from 'react';
+import { useProfileStore } from '../store/useProfileStore';
+import toast from 'react-hot-toast';
+import { Profile } from '../store/useProfileStore';
+
+interface ProfileManagerProps {
+  onLoadProfile: (layoutConfig: any) => void;
+  currentLayoutConfig: any;
+}
+
+const ProfileManager: React.FC<ProfileManagerProps> = ({ onLoadProfile, currentLayoutConfig }) => {
+  const { profiles, createProfile, deleteProfile, loadProfile } = useProfileStore();
+  const [profileName, setProfileName] = useState<string>('');
+
+  const handleCreate = () => {
+    if (!profileName.trim()) {
+      toast.error('Profile name required');
+      return;
+    }
+    createProfile({ name: profileName, layoutConfig: currentLayoutConfig });
+    toast.success('Profile created!');
+    setProfileName('');
+  };
+
+  const handleLoad = (id: string) => {
+    const profile = loadProfile(id);
+    if (profile) {
+      onLoadProfile(profile.layoutConfig);
+      toast.success('Profile loaded');
+    }
+  };
+
+  const handleDelete = (id: string) => {
+    deleteProfile(id);
+    toast('Profile deleted', { icon: '🗑️' });
+  };
+
+  return (
+    <div className="p-4 bg-gray-50 rounded shadow-md w-full max-w-md mx-auto">
+      <h3 className="font-bold text-lg mb-2">Profile Manager</h3>
+      <div className="flex gap-2 mb-4">
+        <input
+          type="text"
+          className="border rounded px-2 py-1 flex-1"
+          placeholder="New profile name"
+          value={profileName}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => setProfileName(e.target.value)}
+        />
+        <button
+          onClick={handleCreate}
+          className="bg-green-600 text-white rounded px-3 py-1 font-semibold hover:bg-green-700"
+        >
+          + New Profile
+        </button>
+      </div>
+      <ul className="divide-y divide-gray-200">
+        {profiles.length === 0 && (
+          <li className="text-gray-400 italic py-2">No profiles saved</li>
+        )}
+        {profiles.map((profile: Profile) => (
+          <li key={profile.id} className="flex items-center justify-between py-2">
+            <span className="font-medium">{profile.name}</span>
+            <div className="flex gap-2">
+              <button
+                onClick={() => handleLoad(profile.id)}
+                className="bg-blue-500 text-white rounded px-2 py-1 text-xs hover:bg-blue-600"
+              >
+                Load
+              </button>
+              <button
+                onClick={() => handleDelete(profile.id)}
+                className="bg-red-500 text-white rounded px-2 py-1 text-xs hover:bg-red-600"
+              >
+                Delete
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ProfileManager;

--- a/arcana-screen/src/components/ProfileManagerPanel.tsx
+++ b/arcana-screen/src/components/ProfileManagerPanel.tsx
@@ -1,0 +1,28 @@
+import ProfileManager from './ProfileManager';
+import { useWidgetStore } from '../store/useWidgetStore';
+
+import type { Widget } from '../store/useWidgetStore';
+
+export default function ProfileManagerPanel() {
+  const widgets = useWidgetStore((state) => state.widgets);
+  const clearWidgets = useWidgetStore((state) => state.clearWidgets);
+  const addWidget = useWidgetStore((state) => state.addWidget);
+
+  // Salva la configurazione attuale dei widget
+  const currentLayoutConfig = widgets;
+
+  // Carica una configurazione profilo
+  const handleLoadProfile = (profileLayout: Widget[]) => {
+    clearWidgets();
+    profileLayout.forEach((w) => addWidget(w));
+  };
+
+  return (
+    <div className="mb-8">
+      <ProfileManager
+        onLoadProfile={handleLoadProfile}
+        currentLayoutConfig={currentLayoutConfig}
+      />
+    </div>
+  );
+}

--- a/arcana-screen/src/components/ProfileManagerReadme.txt
+++ b/arcana-screen/src/components/ProfileManagerReadme.txt
@@ -1,0 +1,22 @@
+Per usare il Profile Manager:
+
+1. Assicurati di avere react-hot-toast tra le dipendenze del progetto:
+   npm install react-hot-toast
+
+2. Importa e monta il componente Toaster nel tuo entry point (es. App.tsx):
+
+   import { Toaster } from 'react-hot-toast';
+   ...
+   <Toaster />
+
+3. Usa <ProfileManager /> dove vuoi gestire i profili.
+   Passa onLoadProfile (funzione che aggiorna il layout) e currentLayoutConfig (config attuale da salvare).
+
+Esempio:
+
+<ProfileManager
+  onLoadProfile={setLayoutConfig}
+  currentLayoutConfig={layoutConfig}
+/>
+
+Il componente mostra la lista dei profili, permette di crearne di nuovi, caricarli o eliminarli, e mostra feedback con toast.

--- a/arcana-screen/src/store/useProfileStore.ts
+++ b/arcana-screen/src/store/useProfileStore.ts
@@ -1,0 +1,51 @@
+import { create } from 'zustand';
+
+export interface Profile {
+  id: string;
+  name: string;
+  layoutConfig: any;
+}
+
+interface ProfileStoreState {
+  profiles: Profile[];
+  createProfile: (profile: Omit<Profile, 'id'>) => void;
+  deleteProfile: (id: string) => void;
+  loadProfile: (id: string) => Profile | undefined;
+}
+
+const LOCAL_STORAGE_KEY = 'arcana_profiles';
+
+const getInitialProfiles = (): Profile[] => {
+  try {
+    const stored = localStorage.getItem(LOCAL_STORAGE_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+};
+
+export const useProfileStore = create<ProfileStoreState>((set, get) => ({
+  profiles: getInitialProfiles(),
+
+  createProfile: (profile) => {
+    const id = Date.now().toString();
+    const newProfile = { ...profile, id };
+    set((state) => {
+      const updated = [...state.profiles, newProfile];
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(updated));
+      return { profiles: updated };
+    });
+  },
+
+  deleteProfile: (id) => {
+    set((state) => {
+      const updated = state.profiles.filter((p) => p.id !== id);
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(updated));
+      return { profiles: updated };
+    });
+  },
+
+  loadProfile: (id) => {
+    return get().profiles.find((p) => p.id === id);
+  },
+}));

--- a/arcana-screen/src/store/useWidgetStore.ts
+++ b/arcana-screen/src/store/useWidgetStore.ts
@@ -19,7 +19,7 @@ export interface Combatant {
   initiative: number;
 }
 
-interface Widget {
+export interface Widget {
   id: string;
   type: string;
   position: { x: number; y: number };


### PR DESCRIPTION
# Profile Manager (#13)

## What was done
- Zustand store for profiles
- UI for create/load/delete
- LocalStorage persistence

## How to test
1. Create new profile
2. Load and verify layout restores
3. Delete and verify persistence removal

## Notes
Minimal styling; ready for future extension

Closes #13 