### PR TITLE
fix: WebKit blanked the app on plain-HTTP hosts via upgrade-insecure-requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes follow [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ### Fixed
 
+- WebKit/Safari rendered a blank app on any plain-HTTP host (local preview, the e2e suite): unlike Chromium/Firefox, WebKit applies `upgrade-insecure-requests` to localhost subresources, so every asset request failed its TLS handshake. The directive now lives only in the production `_headers` file; with all assets same-origin relative, HTTPS deployments lose nothing. The WebKit e2e lane passes for the first time (8/8 + 1 skip).
 - `--as-wine` and `--as-display` were referenced but never defined: the capture "Review N" badge background was invisible and review/source accents fell back to inherited ink. They now map to the token layer (with a dark-theme lift for the wine accent).
 - Dark theme: eyebrows/section labels now lift to `#f0c463` and several popovers (oracle, party glance) use dark surfaces instead of leftover light parchment.
 - Portable backups now include M4 templates, reference packs and appearance preferences while still accepting schema 1 files.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,49 @@
+# HANDOFF — ArcanaScreen
+
+Aggiornato: 2026-07-16 (sessione: adozione design system + prima iterazione product-loop)
+
+## Stato corrente
+
+- Branch `dev` @ `60ba9d7`: adottato il layer di token del progetto Claude Design
+  "Arcana Screen Dungeon Master" (`arcana-screen/src/styles/tokens.css`), body
+  font Inter → Work Sans, fix dei token mai definiti (`--as-wine`, `--as-display`)
+  e del contrasto dark-theme di eyebrow/popover. Pushed su origin/dev.
+- Branch `test/webkit-e2e-gate` @ `9fd61b6` (+ commit docs): **fix del bug
+  cross-browser WebKit** — `upgrade-insecure-requests` nel meta CSP accecava
+  l'app su host HTTP (WebKit forza l'upgrade anche su localhost). Direttiva
+  spostata solo in `public/_headers`. **PR-ready, non mergiato** (policy loop:
+  il merge su dev è una decisione utente → docket D1).
+- Gate (verificati 2026-07-16, loop-verifier PASS): `test:ci` verde (136/136
+  Vitest, lint 0 errori, CSS 119.0/130 KiB); e2e **33 passed + 3 skip, 0 failed
+  sull'intera matrice WebKit incluso** — prima volta. Evidenza:
+  `docs/verification/2026-07-16-webkit-gate.md`.
+
+## Ambiente (questo host sandbox, non il workstation Fedora)
+
+- sudo passwordless disponibile; Playwright chromium/firefox/**webkit** installati
+  con dipendenze di sistema (`~/.cache/ms-playwright`).
+- `gh` autenticato (MissingPackage); identità git configurata repo-local.
+- Linear MCP **non autenticato** in sessioni non interattive: il docket file
+  `docs/DOCKET.md` è il tracker operativo finché Linear non è raggiungibile.
+
+## §next-decidable (in ordine)
+
+1. **Prova Timer dopo sospensione lunga/background** (ROADMAP Sequenza immediata
+   item 2, seconda metà — l'unica parte ancora aperta dell'item). Slice: test
+   e2e/harness che simula sospensione (clock skew / page freeze) e verifica il
+   ricalcolo da timestamp.
+2. **Conferma lane WebKit nella CI GitHub**: push/PR del branch
+   `test/webkit-e2e-gate` esercita il workflow `Quality gate` con la matrice
+   browser. Osservare il run, chiudere l'item 2 prima metà anche in CI.
+3. Righe acceptance-matrix non verdi legate a WebKit (`docs/specs/acceptance-matrix.md`)
+   da riesaminare dopo il merge del fix.
+4. Residui design-system: vedi docket D3–D5.
+
+Item 1 e 3 della Sequenza immediata (sessioni con DM reali, PWA su device
+reali) restano human-gated: non decidibili in loop.
+
+## Protocollo
+
+Loop attivo: `/loop /product-loop` (self-paced). Ogni iterazione: re-anchor da
+questo file + `docs/DOCKET.md` → una slice → gate completi → loop-verifier →
+digest. Merge su dev e decisioni di scope: solo l'utente.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ Stato (verificato 2026-07-14): Orizzonti 1–4 implementati.
 
 **Stato reale misurato (2026-07-14, non aspirazionale):**
 
-- Unit/component: **86/86 verdi** (`npm run test:ci` = build + lint + 86 Vitest + budget).
+- Unit/component: **136/136 verdi** (`npm run test:ci` = build + lint + Vitest + budget; conteggio aggiornato 2026-07-16).
 - E2e Playwright (`test:e2e:critical`): **33 passati + 3 skip intenzionali** sull'intera matrice, **WebKit incluso** (aggiornato 2026-07-16). Il bug cross-browser Safari è stato individuato e corretto: era `upgrade-insecure-requests` nel meta CSP — WebKit (a differenza di Chromium/Firefox) forza l'upgrade anche su localhost, quindi ogni asset falliva il TLS handshake e l'app restava bianca su qualsiasi host HTTP. La direttiva ora vive solo in `public/_headers` (deploy HTTPS). Evidenza: `docs/verification/2026-07-16-webkit-gate.md`. Resta aperta la conferma del lane WebKit nella CI GitHub.
 - **Accessibilità:** il gate axe era in realtà **RED** (93 violazioni di contrasto sul testo muted, regressione introdotta dal re-skin Prepare). **Corretto il 2026-07-14** (`--ink-muted`/`--as-muted` → `#586678`, ora AA ≥ 4.5:1); ora verde su Chromium/Firefox/mobile.
 - **Budget performance:** alzato il 2026-07-14 a **560 KiB JS / 110 KiB CSS** (era 500/100) per accogliere le icone per-entità; attuale 528.9/96.3.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Stato (verificato 2026-07-14): Orizzonti 1–4 implementati.
 **Stato reale misurato (2026-07-14, non aspirazionale):**
 
 - Unit/component: **86/86 verdi** (`npm run test:ci` = build + lint + 86 Vitest + budget).
-- E2e Playwright (`test:e2e:critical`): **25 passati + 2 skip intenzionali** su Chromium desktop/mobile e Firefox. **WebKit:** sull'host Fedora non si avvia (dipendenze); ma nel container Playwright (podman, immagine `v1.61.1-noble`) **parte e fallisce 8/9 con `element not found`** → **bug reale cross-browser (Safari)**, finora mascherato perché WebKit non girava mai. Workstream aperto: triage compat WebKit (girare l'e2e nel container).
+- E2e Playwright (`test:e2e:critical`): **33 passati + 3 skip intenzionali** sull'intera matrice, **WebKit incluso** (aggiornato 2026-07-16). Il bug cross-browser Safari è stato individuato e corretto: era `upgrade-insecure-requests` nel meta CSP — WebKit (a differenza di Chromium/Firefox) forza l'upgrade anche su localhost, quindi ogni asset falliva il TLS handshake e l'app restava bianca su qualsiasi host HTTP. La direttiva ora vive solo in `public/_headers` (deploy HTTPS). Evidenza: `docs/verification/2026-07-16-webkit-gate.md`. Resta aperta la conferma del lane WebKit nella CI GitHub.
 - **Accessibilità:** il gate axe era in realtà **RED** (93 violazioni di contrasto sul testo muted, regressione introdotta dal re-skin Prepare). **Corretto il 2026-07-14** (`--ink-muted`/`--as-muted` → `#586678`, ora AA ≥ 4.5:1); ora verde su Chromium/Firefox/mobile.
 - **Budget performance:** alzato il 2026-07-14 a **560 KiB JS / 110 KiB CSS** (era 500/100) per accogliere le icone per-entità; attuale 528.9/96.3.
 

--- a/arcana-screen/index.html
+++ b/arcana-screen/index.html
@@ -9,7 +9,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="A local-first, customizable screen for tabletop game masters." />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests" />
+    <!-- upgrade-insecure-requests lives in public/_headers only: WebKit (unlike
+         Chromium/Firefox) upgrades localhost subresources too, which blanks the
+         app on any plain-HTTP host (vite preview, the e2e suite). All assets are
+         same-origin relative, so on HTTPS the directive is redundant here. -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; form-action 'self'" />
     <title>ArcanaScreen</title>
   </head>
   <body class="light-theme">

--- a/arcana-screen/public/privacy.html
+++ b/arcana-screen/public/privacy.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'" />
     <title>Privacy · ArcanaScreen</title>
     <style>
       body { max-width: 48rem; margin: 0 auto; padding: 2rem 1rem 4rem; color: #172b47; background: #f8f3e8; font: 1rem/1.65 "Work Sans", Inter, system-ui, sans-serif; }

--- a/docs/DOCKET.md
+++ b/docs/DOCKET.md
@@ -1,0 +1,30 @@
+# DOCKET — decisioni e residui (PI-gated)
+
+Convenzione: una riga per item, `D<n> [data] [tipo]` — l'utente decide, il loop
+non li assorbe. Quando Linear è raggiungibile, migrare gli item aperti.
+
+## Aperti
+
+- D1 [2026-07-16] [merge] Mergiare `test/webkit-e2e-gate` → `dev` (fix CSP
+  WebKit, verifier PASS, evidenza in docs/verification/2026-07-16-webkit-gate.md).
+  Il loop non merge-a per policy.
+- D2 [2026-07-16] [bug/dark-theme] Input con `background: #fff` fisso
+  (`.initiative-input`, `.batch-init__rows input`, `.mint-npc-form input`,
+  `.encounter-add__form input` in session.css) restano bianchi in dark theme con
+  testo `--as-ink` pergamena → illeggibili. Trovato durante la token sweep, fuori
+  scope della slice.
+- D3 [2026-07-16] [design/decisione] Il DS definisce `color-scheme: light/dark`
+  (colors.css); non adottato per non cambiare il rendering nativo di
+  scrollbar/controlli. Decidere se adottarlo.
+- D4 [2026-07-16] [design/coverage] Letterali non tokenizzati residui:
+  session.css (famiglia `#314c64`/`#526779`, gold wash `#fff8e7/#fff8e8/#fffaf0`,
+  cerchietti beat `#b98618`) e la sweep profonda di index.css (~2900 righe).
+  Candidato per /pattern-coverage.
+- D5 [2026-07-16] [docs] ROADMAP riga budget dice "560 KiB JS / 110 KiB CSS" ma
+  lo script applica 130 KiB CSS (CLAUDE.md corretto). Riconciliare.
+- D6 [2026-07-16] [ci] Confermare il lane WebKit nel workflow `Quality gate` su
+  GitHub Actions al prossimo push/PR (next-decidable #2).
+
+## Chiusi
+
+(vuoto)

--- a/docs/verification/2026-07-16-webkit-gate.md
+++ b/docs/verification/2026-07-16-webkit-gate.md
@@ -1,0 +1,58 @@
+# 2026-07-16 — WebKit e2e gate: root cause e verifica
+
+## Contesto
+
+Il gate WebKit non era mai stato eseguibile sul workstation Fedora (dipendenze di
+sistema non installabili). Nel container Playwright falliva 8/9 con `element not
+found`, documentato in ROADMAP come "bug reale cross-browser (Safari), workstream
+aperto". Questo host (sandbox Ubuntu con sudo) ha permesso di installare WebKit
+26.5 (`playwright webkit v2311`) ed eseguire il gate per la prima volta.
+
+## Riproduzione
+
+`npx playwright test --project=webkit-desktop` → **8 failed + 1 skipped**, tutti
+in `createScreen` con `getByRole('heading', { name: 'Create a useful screen
+first' })` non trovato. Identico al risultato container: bug reale, non flakiness.
+
+## Root cause
+
+Probe diretto (WebKit + `page.on('console')`) sulla preview `http://localhost:4173`:
+
+```
+[console.error] Failed to load resource: Error performing TLS handshake: An unexpected TLS packet was received.   (×6)
+--- #root children: 0 ---
+```
+
+Le subresource venivano richieste come `https://localhost:4173/...` contro un
+server HTTP puro. Causa: `upgrade-insecure-requests` nel meta CSP di
+`index.html`. Chromium e Firefox esentano localhost dall'upgrade; **WebKit lo
+applica anche a localhost**, quindi nessun asset JS si carica e l'app resta
+bianca su qualunque host HTTP (preview locale, suite e2e, container CI).
+
+## Fix
+
+- Rimossa la direttiva dai meta CSP di `index.html` e `public/privacy.html`.
+- Mantenuta in `public/_headers` (header di deploy, attivo solo dove il sito è
+  servito su HTTPS con supporto custom headers).
+- Verificato che nessuna risorsa è referenziata via `http://` (grep su src/,
+  public/, index.html): su origin HTTPS tutti gli asset sono già HTTPS per
+  costruzione, quindi la rimozione dal meta è un no-op di produzione.
+
+## Verifica
+
+- `npx playwright test --project=webkit-desktop`: **8 passed + 1 skipped** (lo
+  skip è il test touch-target riservato al progetto mobile).
+- `npm run test:e2e:critical` (matrice completa Chromium desktop/mobile,
+  Firefox, WebKit): **33 passed + 3 skipped, 0 failed** — prima volta con il
+  lane WebKit verde.
+- `npm run test:ci`: build ok, lint 0 errori (4 warning preesistenti), 136/136
+  Vitest, budget 119.0/130 KiB CSS.
+
+## Non verificato
+
+- Il lane WebKit nella CI GitHub (`Quality gate` con `--with-deps`): da
+  confermare alla prossima PR/push. Safari reale (macOS/iOS) non testato
+  direttamente; l'engine è lo stesso ma la conferma su device resta nel gate
+  di accettazione prodotto.
+- La prova Timer dopo sospensione lunga/background (seconda metà dell'item 2
+  della Sequenza immediata) resta aperta.


### PR DESCRIPTION
## Problem
The WebKit e2e lane has failed 8/9 with `element not found` since it first ran (previously masked because WebKit never launched on the dev host). Root cause: `upgrade-insecure-requests` in the HTML CSP meta. WebKit — unlike Chromium/Firefox — applies the upgrade to localhost subresources, so on any plain-HTTP host (vite preview, the e2e suite) every asset request became `https://` against an HTTP server, failed its TLS handshake, and the app rendered a blank `#root`.

## Fix
- Remove the directive from `index.html` and `public/privacy.html` metas.
- Keep it in `public/_headers` (HTTPS deploy header), preserving production hardening.
- All assets are same-origin relative (verified: zero plain-http references), so this is a production no-op.

## Evidence
- WebKit lane: **8 passed + 1 skipped** (was 8 failed).
- Full matrix (Chromium desktop/mobile, Firefox, WebKit): **33 passed + 3 skipped, 0 failed** — first all-green run including WebKit.
- `test:ci`: 136/136 Vitest, lint 0 errors, budget 119.0/130 KiB CSS.
- Full write-up: `docs/verification/2026-07-16-webkit-gate.md`. Independent re-verification reproduced all counts.

Also journals the iteration (HANDOFF.md, docs/DOCKET.md) and refreshes stale ROADMAP counts.