### PR TITLE
fix: dark-theme inputs no longer keep a white background under parchment ink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes follow [Keep a Changelog](https://keepachangelog.com/en/1.1.
 - `--as-wine` and `--as-display` were referenced but never defined: the capture "Review N" badge background was invisible and review/source accents fell back to inherited ink. They now map to the token layer (with a dark-theme lift for the wine accent).
 - Dark theme: eyebrows/section labels now lift to `#f0c463` and several popovers (oracle, party glance) use dark surfaces instead of leftover light parchment.
 - Portable backups now include M4 templates, reference packs and appearance preferences while still accepting schema 1 files.
+- Dark theme: the initiative, batch-initiative, mint-NPC and add-combatant inputs kept a hardcoded white background under parchment-cream ink (~1.35:1, unreadable). They now use the raised-surface token (`--as-surface-raised`), identical in light theme and 10.2:1 in dark.
 
 ## [1.0.0-rc.1] — 2026-07-13
 

--- a/arcana-screen/src/components/session/session.css
+++ b/arcana-screen/src/components/session/session.css
@@ -409,7 +409,7 @@
 .npc-list button { align-self: start; padding: 4px 7px !important; border: 1px solid #c6ad77 !important; border-radius: 4px !important; color: #79510b !important; background: #fff4d4 !important; font-size: 9px !important; }
 .section-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
 .mint-npc-form { display: flex; align-items: center; gap: 6px; }
-.arcana-session .mint-npc-form input { width: 118px; padding: 5px 8px; color: var(--as-ink); background: #fff; border: 1px solid var(--as-line-strong); border-radius: 5px; font-size: 11px; }
+.arcana-session .mint-npc-form input { width: 118px; padding: 5px 8px; color: var(--as-ink); background: var(--as-surface-raised); border: 1px solid var(--as-line-strong); border-radius: 5px; font-size: 11px; }
 .arcana-session .mint-npc { display: inline-flex; align-items: center; gap: 5px; min-height: 30px; padding: 4px 11px; color: var(--as-ink); background: transparent; border: 1px solid var(--as-line-strong); border-radius: 6px; font-size: 11px; font-weight: 700; cursor: pointer; white-space: nowrap; }
 .arcana-session .mint-npc:hover { border-color: var(--as-gold-strong); }
 .npc-actions { display: flex; align-items: start; gap: 6px; }
@@ -549,7 +549,7 @@ body[data-density='compact'] .arcana-session .combatant-identity > span:first-ch
 .arcana-session button.initiative-score:hover, .arcana-session button.initiative-score:focus-visible { color: var(--as-gold-ink); border-bottom-color: var(--as-gold-ink); border-bottom-style: solid; }
 .arcana-session button.initiative-score:hover svg, .arcana-session button.initiative-score:focus-visible svg { color: var(--as-gold-ink); }
 .arcana-session .initiative-score--unset { color: var(--as-ink-muted); }
-.arcana-session .initiative-input { width: 56px; padding: 2px 5px; color: var(--as-ink); background: #fff; border: 1px solid var(--as-line-strong); border-radius: 5px; font-family: var(--as-font-display); font-size: 20px; }
+.arcana-session .initiative-input { width: 56px; padding: 2px 5px; color: var(--as-ink); background: var(--as-surface-raised); border: 1px solid var(--as-line-strong); border-radius: 5px; font-family: var(--as-font-display); font-size: 20px; }
 .tracker-hint { margin: 0; padding: 6px 13px; color: var(--as-ink-muted); font-size: 11px; font-style: italic; }
 .tracker-tools { display: flex; align-items: center; gap: 14px; }
 .arcana-session .batch-init-toggle { display: inline-flex; align-items: center; gap: 6px; min-height: 30px; padding: 4px 11px; color: var(--as-ink); background: transparent; border: 1px solid var(--as-line-strong); border-radius: 6px; font-size: 11px; font-weight: 700; cursor: pointer; }
@@ -560,7 +560,7 @@ body[data-density='compact'] .arcana-session .combatant-identity > span:first-ch
 .batch-init__hint { margin: 0 0 12px; color: var(--as-ink-muted); font-size: 11px; font-style: italic; }
 .batch-init__rows { display: grid; grid-auto-flow: column; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px 26px; }
 .batch-init__rows label { display: grid; grid-template-columns: 1fr 58px; align-items: center; gap: 8px; font-size: 12px; color: var(--as-ink); }
-.arcana-session .batch-init__rows input { padding: 3px 6px; color: var(--as-ink); background: #fff; border: 1px solid var(--as-line-strong); border-radius: 5px; font-family: var(--as-font-display); font-size: 15px; text-align: center; }
+.arcana-session .batch-init__rows input { padding: 3px 6px; color: var(--as-ink); background: var(--as-surface-raised); border: 1px solid var(--as-line-strong); border-radius: 5px; font-family: var(--as-font-display); font-size: 15px; text-align: center; }
 .batch-init__actions { display: flex; gap: 8px; margin-top: 13px; }
 .arcana-session .batch-init__actions button[type="submit"] { padding: 6px 16px; color: var(--as-gold-contrast); background: var(--as-gold); border: 1px solid var(--as-gold-strong); border-radius: 6px; font-weight: 700; cursor: pointer; }
 .arcana-session .batch-init__actions button[type="button"] { padding: 6px 14px; color: var(--as-ink); background: transparent; border: 1px solid var(--as-line-strong); border-radius: 6px; cursor: pointer; }
@@ -569,7 +569,7 @@ body[data-density='compact'] .arcana-session .combatant-identity > span:first-ch
 .arcana-session .encounter-add__toggle:hover { border-color: var(--as-gold-strong); }
 .encounter-add__form { display: flex; flex-wrap: wrap; align-items: center; gap: 8px 10px; padding: 10px 12px; background: var(--as-paper-deep); border: 1px solid var(--as-line-strong); border-radius: 8px; }
 .encounter-add__form .add-field { display: inline-flex; align-items: center; gap: 5px; font-size: 10px; font-weight: 700; letter-spacing: .04em; text-transform: uppercase; color: var(--as-ink-muted); }
-.arcana-session .encounter-add__form input { padding: 5px 7px; color: var(--as-ink); background: #fff; border: 1px solid var(--as-line-strong); border-radius: 5px; font-size: 12px; }
+.arcana-session .encounter-add__form input { padding: 5px 7px; color: var(--as-ink); background: var(--as-surface-raised); border: 1px solid var(--as-line-strong); border-radius: 5px; font-size: 12px; }
 .arcana-session .encounter-add__form input.add-name { flex: 1 1 150px; min-width: 130px; }
 .arcana-session .encounter-add__form .add-field input { width: 52px; text-align: center; }
 .arcana-session .encounter-add__form button[type="submit"] { padding: 6px 15px; color: var(--as-gold-contrast); background: var(--as-gold); border: 1px solid var(--as-gold-strong); border-radius: 6px; font-weight: 700; cursor: pointer; }


### PR DESCRIPTION
## What (docket D2)
Four Run-cockpit inputs — initiative score, batch initiative, mint NPC, add combatant — hardcoded `background: #fff` with `color: var(--as-ink)`. In dark theme the ink flips to parchment cream, giving cream-on-white at **~1.35:1**: unreadable. They now use `var(--as-surface-raised)` — `#ffffff` in light theme (pixel-identical) and `#263553` in dark.

## Evidence
- Runtime probe on the production build, dark theme, real input mounted: `bg rgb(38,53,83)` / `color rgb(245,234,210)` → **contrast 10.24:1**.
- `test:ci`: 136/136, lint 0 errors, CSS 119.1/130 KiB.
- e2e on this branch (chromium desktop/mobile + firefox): 25 passed + 2 skipped.
- Full matrix **including WebKit** verified on a local integration merge with #83/#84 (WebKit can't load the app without #83's CSP fix): **37 passed + 3 skipped, 0 failed**.

The dice/timer popover inputs keep their existing working dark overrides — untouched (broader literal sweep is docket D4).

Independent of #83/#84; merges to dev in any order (changelog line placed to avoid conflicts).