### PR TITLE
fix: dark theme kept cream text on the active Prepare/Run toggle (1.24:1)

### DIFF
--- a/arcana-screen/src/index.css
+++ b/arcana-screen/src/index.css
@@ -812,8 +812,15 @@
    }
 
    .arcana-header button.screen-mode__button[aria-pressed='true'] {
-     color: #102b49;
+     color: var(--as-gold-contrast);
      background: #f5cf72;
+   }
+
+   /* The dark-theme base rule above (body.dark-theme … .screen-mode__button,
+      specificity 0-3-2) outranks the active rule (0-3-1): without this, the
+      pressed toggle kept cream text on its gold fill in dark — 1.24:1. */
+   body.dark-theme .arcana-header button.screen-mode__button[aria-pressed='true'] {
+     color: var(--as-gold-contrast);
    }
 
    .arcana-header .screen-manager__saved { color: #8fe1a8; white-space: nowrap; }


### PR DESCRIPTION
## What (docket D11, first half)
In dark theme the **active** Prepare/Run toggle in the header was effectively unreadable: axe measured `#f1e9dc` cream text on the `#f5cf72` gold fill — **1.24:1**. Root cause is CSS specificity: the dark base rule `body.dark-theme .arcana-header button.screen-mode__button` (0-3-2) outranks the active rule `.arcana-header button.screen-mode__button[aria-pressed='true']` (0-3-1), so the dark cream overrode the navy ink while the gold background still applied.

Fix: a dark-scoped active rule restoring `var(--as-gold-contrast)` (measured at runtime: **7.9:1**); the light rule's hardcoded `#102b49` is tokenized in passing.

## Evidence
- Runtime probe post-fix: active toggle `rgb(16,43,73)` on `rgb(245,207,114)`.
- **Dark-theme axe of the Prepare shell: 0 violations** — first ever dark scan of the shell.
- Dark axe of the integrated state (this + #83/#84 + #87): Narrative/Exploration/Combat/Prepare all **0**; the Social focus initially showed 2 nodes — one is fixed by #85 (mint-NPC input), the other was a gap in #87's own sweep (npc chip background), fixed with a follow-up commit on #87's branch.
- `test:ci`: 136/136, lint 0 errors, CSS 119.1/130 KiB. e2e (3 lanes): 25 passed + 2 skipped. Full matrix incl. WebKit on the integration merge: **37 passed + 3 skipped, 0 failed**.

Remaining D11 scope (index.css deep literal sweep, ~2900 lines) stays docketed — separate, larger slice.

WebKit CI lane red until #83 merges (known).